### PR TITLE
Except both AttributeError and PermissionError in set_pu

### DIFF
--- a/backend_py/src/device.py
+++ b/backend_py/src/device.py
@@ -374,13 +374,14 @@ class Device(events.EventEmitter):
                         if self._options[option_name].name == control.name:
                             self.set_option(option_name, value)
                             return
+            return # in case the id does not exist in controls
 
         control = self.v4l2_device.controls[control_id]
         logging.info(self._fmt_log(f'Setting UVC control - {control.name} to {value}'))
         try:
             control.value = value
-        except AttributeError:
-            pass
+        except (AttributeError, PermissionError) as e:
+            logging.warning(f'Error setting control value: {e.strerror}')
         for ctrl in self.controls:
             if ctrl.control_id == control_id:
                 ctrl.value = value


### PR DESCRIPTION
# Description

Prior to this fix, there was an issue where setting the white balance of a camera when AI AWB is disabled would result in a permission error. This is the expected behavior from the camera, however it was not handled properly in the backend.

## Type of change

Please select all that apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other: [describe here]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Make sure code runs/builds on Linux **[REQUIRED]**
  - [X] Code produces no console errors upon launching the software
- [X] Other (add any other tests run)
  - [X] Test setting white balance when AWB is enabled

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have added 1 or more reviewers to my pull request
  - [ ] Reviewer has run the above tests to verify
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Myself or a reviewer has tested my code to prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
