### PR TITLE
Bump version and do not show settingscard until settings are loaded

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deepwaterexploration/dwe-os-2",
-    "version": "v0.2.1-alpha",
+    "version": "v0.2.2-alpha",
     "description": "Web-based driver and software interface for DWE.ai cameras",
     "main": "lib/main.tsx",
     "keywords": [

--- a/frontend/src/layouts/preferences/index.tsx
+++ b/frontend/src/layouts/preferences/index.tsx
@@ -8,9 +8,9 @@ import TextFieldButton from "../../components/TextFieldButton";
 import { useSnackbar } from "notistack";
 
 const PreferencesLayout = () => {
-    const [host, setHost] = useState("192.168.2.1");
-    const [port, setPort] = useState(5600);
     const { enqueueSnackbar } = useSnackbar();
+    const [host, setHost] = useState(undefined);
+    const [port, setPort] = useState(undefined);
 
     useEffect(() => {
         getSettings().then((settings) => {
@@ -32,42 +32,46 @@ const PreferencesLayout = () => {
                 padding: "0 3em",
             }}
         >
-            <SettingsCard cardTitle='Stream'>
-                <TextField
-                    sx={styles.settingsButton.textInput}
-                    label='Default Stream Host'
-                    onChange={(e) => {
-                        setHost(e.target.value);
-                    }}
-                    value={host}
-                    variant='outlined'
-                    size='small'
-                />
-                <TextField
-                    sx={styles.settingsButton.textInput}
-                    label='Default Stream Port'
-                    onChange={(e) => setPort(parseInt(e.target.value))}
-                    value={port}
-                    variant='outlined'
-                    size='small'
-                    type='number'
-                    inputProps={{ min: 1024, max: 65535 }}
-                />
-                <Button
-                    sx={styles.settingsButton.button}
-                    variant='contained'
-                    onClick={() => {
-                        if (IP_REGEX.test(host))
-                            savePreferences({ default_stream: { host, port } });
-                        else
-                            enqueueSnackbar("Invalid IP Address", {
-                                variant: "error",
-                            });
-                    }}
-                >
-                    Save
-                </Button>
-            </SettingsCard>
+            {host === undefined || port === undefined || (
+                <SettingsCard cardTitle='Stream'>
+                    <TextField
+                        sx={styles.settingsButton.textInput}
+                        label='Default Stream Host'
+                        onChange={(e) => {
+                            setHost(e.target.value);
+                        }}
+                        value={host}
+                        variant='outlined'
+                        size='small'
+                    />
+                    <TextField
+                        sx={styles.settingsButton.textInput}
+                        label='Default Stream Port'
+                        onChange={(e) => setPort(parseInt(e.target.value))}
+                        value={port}
+                        variant='outlined'
+                        size='small'
+                        type='number'
+                        inputProps={{ min: 1024, max: 65535 }}
+                    />
+                    <Button
+                        sx={styles.settingsButton.button}
+                        variant='contained'
+                        onClick={() => {
+                            if (IP_REGEX.test(host))
+                                savePreferences({
+                                    default_stream: { host, port },
+                                });
+                            else
+                                enqueueSnackbar("Invalid IP Address", {
+                                    variant: "error",
+                                });
+                        }}
+                    >
+                        Save
+                    </Button>
+                </SettingsCard>
+            )}
         </Grid>
     );
 };


### PR DESCRIPTION
# Description

Fix issue where ui would show default preferences before loading the correct ones from the server. This caused the UI to look less clean.

## Type of change

Please select all that apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other: [describe here]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Make sure code runs/builds on Linux **[REQUIRED]**
  - [X] Code produces no console errors upon launching the software
- [ ] Other (add any other tests run)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have added 1 or more reviewers to my pull request
  - [ ] Reviewer has run the above tests to verify
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Myself or a reviewer has tested my code to prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
