### PR TITLE
Fix issue with exception handling in NetworkManager

### DIFF
--- a/backend_py/src/services/wifi/wifi_manager.py
+++ b/backend_py/src/services/wifi/wifi_manager.py
@@ -91,15 +91,12 @@ class WiFiManager:
 
             # this is used so the server does not hang on close
             if elapsed_time >= self.scan_interval:
+                # Make sure the scan stops when we are no longer scanning
                 try:
-                    # Make sure the scan stops when we are no longer scanning
-                    try:
-                        self.access_points = self.nm.scan_wifi(lambda: self._is_scanning)
-                        self.status.finished_first_scan = True
-                    except NMException as e:
-                        logging.error(f'Error occurred while scanning: {e}.')
-                except TimeoutError as e:
-                    logging.warning(e)
+                    self.access_points = self.nm.scan_wifi(lambda: self._is_scanning)
+                    self.status.finished_first_scan = True
+                except NMException as e:
+                    logging.error(f'Error occurred while scanning: {e}.')
 
                 # reset the counter
                 start_time = current_time


### PR DESCRIPTION
# Description

Prior to this PR, there was an issue with exception handling in NetworkManager. The NMException was not correctly getting triggered when a DBusException occurred. This would cause a thread crash, fatally killing the WiFiManager completely. This would require a program restart. This is bad. Other parts of NetworkManager need to be looked at to ensure the same issue will not happen. It should be noted this is extremely unlikely to happen and seems to only be reproduce-able upon a PC exiting the sleep state.

## Type of change

Please select all that apply.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other: [describe here]

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Make sure code runs/builds on Linux **[REQUIRED]**
  - [X] Code produces no console errors upon launching the software
- [ ] Other (add any other tests run)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added 1 or more reviewers to my pull request
  - [ ] Reviewer has run the above tests to verify
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Myself or a reviewer has tested my code to prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
