### PR TITLE
VID/PID Checking frame sync board SVC Pro

### DIFF
--- a/backend_py/run.py
+++ b/backend_py/run.py
@@ -44,7 +44,7 @@ app.add_middleware(
 # Server instance
 # server = Server(FeatureSupport.none(), sio, app, settings_path='.')
 server = Server(
-    FeatureSupport(ttyd=True, wifi=True, serial=False), sio, app, settings_path=".", log_level=logging.DEBUG, is_dev_mode=True
+    FeatureSupport(ttyd=True, wifi=True, serial=True), sio, app, settings_path=".", log_level=logging.DEBUG, is_dev_mode=True
 )
 
 # Combine FastAPI and Socket.IO ASGI apps

--- a/backend_py/src/server.py
+++ b/backend_py/src/server.py
@@ -171,6 +171,9 @@ class Server:
         # loop over and emit the logs to the client
         asyncio.create_task(self.emit_logs())
 
+        if self.feature_support.serial:
+            self.device_manager.serial.start()
+
         self.device_manager.start_monitoring()
         if self.feature_support.wifi:
             self.wifi_manager.start_scanning()

--- a/backend_py/src/services/cameras/device_manager.py
+++ b/backend_py/src/services/cameras/device_manager.py
@@ -71,7 +71,6 @@ class DeviceManager(events.EventEmitter):
         self.serial = None
         if use_serial:
             self.serial = SerialPWMController()
-            self.serial.start()
 
         self.logger = logging.getLogger("dwe_os_2.cameras.DeviceManager")
 
@@ -90,6 +89,9 @@ class DeviceManager(events.EventEmitter):
 
         for device in self.devices:
             device.stream.stop()
+
+        if self.serial:
+            self.serial.close()
 
     def create_device(self, device_info: DeviceInfo) -> Device | None:
         """

--- a/backend_py/src/services/cameras/pwm/serial_pwm_controller.py
+++ b/backend_py/src/services/cameras/pwm/serial_pwm_controller.py
@@ -1,62 +1,104 @@
 import serial
 import logging
 import asyncio
-import time
 from serial.tools import list_ports
 
+PWM_USB_VID = 0x3961
+PWM_USB_PID = 0x5000
+
 frequency_table = {
-  60: 60.0,
-  50: 50.0,
-  40: 40.0,
-  30: 30.0,
-  15: 15.0
+    60: 60.0,
+    50: 50.0,
+    40: 40.0,
+    30: 30.0,
+    15: 15.0
 }
 
-def find_ch341_device():
-    print(list_ports.comports())
-    raise RuntimeError("CH341 USB Serial device not found")
+MONITOR_INTERVAL_SEC = 0.75
+
+
+def _find_pwm_device_path() -> str | None:
+    """
+    Find the PWM device path of a DWE frame synchronization board:
+
+    `3961:5000 DeepWater Exploration Frame Sync Module`
+    """
+    for port in list_ports.comports():
+        if port.vid is None or port.pid is None:
+            continue
+        if port.vid == PWM_USB_VID and port.pid == PWM_USB_PID:
+            return port.device
+    return None
 
 
 class SerialPWMController:
-    def __init__(self, port: str = "/dev/ttyUSB0", baudrate: int = 9600):
+    def __init__(self, baudrate: int = 9600):
         self.found_port = False
         self.has_printed_error = False
 
-        self.port = port
         self.logger = logging.getLogger("dwe_os_2.pwm.SerialPWMController")
         self.baudrate = baudrate
         self.frequency = 0
         self.duty_cycle = 0
+        self.serial = None
+        self._monitor_task: asyncio.Task | None = None
+        self._running = False
 
-    def _open_serial(self):
-        while True:
+    def _disconnect_serial(self) -> None:
+        self.found_port = False
+        if self.serial is not None:
             try:
-                if not self.found_port:
-                    self.serial = serial.Serial(
-                        port=self.port, baudrate=self.baudrate, timeout=1)
-                    self.found_port = True
+                if self.serial.is_open:
+                    self.serial.close()
+            except Exception:
+                pass
+            self.serial = None
 
-                    # Initial apply
-
-                    for _ in range(10):
-                        line = self.serial.readline().decode('utf-8').strip()
-                        if 'PWM frequency' in line:
-                            self.logger.info('APPLYING INITIAL CONFIG')
-                            self.logger.info(line)
+    async def _monitor_loop(self) -> None:
+        try:
+            while self._running:
+                path = _find_pwm_device_path()
+                if path:
+                    if self.found_port and self.serial is not None:
+                        if self.serial.port != path or not self.serial.is_open:
+                            self._disconnect_serial()
+                    if not self.found_port:
+                        try:
+                            self.serial = serial.Serial(
+                                port=path, baudrate=self.baudrate, timeout=1
+                            )
+                            self.found_port = True
+                            self.has_printed_error = False
+                            self.logger.info(
+                                "PWM USB serial connected at %s", path
+                            )
+                            # Perform initial apply
                             self.apply(self.frequency, self.duty_cycle)
-                            return
-                        time.sleep(1)
-
-                    logging.error('Firmware is likely bad on pwm controller.')
+                        except serial.serialutil.SerialException as e:
+                            if not self.has_printed_error:
+                                self.logger.error(
+                                    "PWM serial open failed: %s", e
+                                )
+                                self.has_printed_error = True
+                            self._disconnect_serial()
                 else:
-                    break
-            except serial.serialutil.SerialException as e:
-                self.has_printed_error = True
-                self.logger.error(f"No serial port found: {e}")
+                    if self.found_port:
+                        self._disconnect_serial()
+                        self.logger.info("PWM USB serial disconnected")
+
+                # May be better to trigger this only when a frequency is applied
+                await asyncio.sleep(MONITOR_INTERVAL_SEC)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            self._disconnect_serial()
 
     def start(self):
         """Starts the background asyncio task to sync settings."""
-        self._open_serial()
+        if self._monitor_task is not None and not self._monitor_task.done():
+            return
+        self._running = True
+        self._monitor_task = asyncio.create_task(self._monitor_loop())
 
     def apply(self, frequency: float, duty_cycle: int):
         # Make sure that even if the serial pwm is not yet connected, it will
@@ -67,7 +109,7 @@ class SerialPWMController:
             self.logger.info(f"No connected USB serial PWM controller")
             return
         command = f"{frequency},{duty_cycle}\n"
-        self.logger.info(f"Sending command {command}")
+        self.logger.info(f"Sending command {command.strip()}")
         self.serial.write(command.encode("utf-8"))
 
     def apply_from_fps(self, fps: int):
@@ -77,8 +119,11 @@ class SerialPWMController:
         self.apply(0, 0)
 
     def close(self):
-        if self.serial.is_open:
-            self.serial.close()
+        self._running = False
+        if self._monitor_task is not None:
+            self._monitor_task.cancel()
+            self._monitor_task = None
+        self._disconnect_serial()
 
     def get_current_config(self) -> tuple[float, int]:
         return (self.frequency, self.duty_cycle)


### PR DESCRIPTION
# Description

Add VID/PID search for SVC Pro frame synchronization board. This has the side effect of solving #486

Addresses #487 

## Breaking behavior

Serial should always be enabled by default. It will now automatically fail silently when no serial board is detected. Initial failed detection will be logged.