### PR TITLE
recording tweaks

### DIFF
--- a/backend_py/src/routes/recordings.py
+++ b/backend_py/src/routes/recordings.py
@@ -6,6 +6,7 @@ Handles listing recording metadata, downloading / deleting / renaming recordings
 and downloading all recordings as ZIP
 """
 
+import asyncio
 import os
 import shutil
 import time
@@ -27,30 +28,36 @@ class DiskStatsResponse(BaseModel):
     used: int
     free: int
 
-
-# dict of timp file paths
-download_tokens: dict[str, dict] = {}
-
+active_zip_jobs: dict[str, dict] = {}
 
 # Helpers
 def remove_file(path: str) -> None:
     if os.path.exists(path):
         os.remove(path)
 
+# for refreshes during downloads
+async def auto_cleanup_job(job_id: str) -> None:
+    await asyncio.sleep(600)  # Wait 10 minutes
+    if job_id in active_zip_jobs:
+        data = active_zip_jobs.pop(job_id)
+        if data.get("path"):
+            remove_file(data["path"])
+            
+def background_zip_worker(job_id: str, filenames: list[str], service: RecordingsService):
+    try:
+        zip_path = service.zip_recordings(filenames, active_jobs=active_zip_jobs, job_id=job_id)
+        
+        if zip_path == "CANCELLED":
+            active_zip_jobs.pop(job_id, None)
+            return
 
-def clean_orphaned_tokens() -> None:
-    current_time = time.time()
-    expired_tokens = []
-
-    for token, data in download_tokens.items():
-        if current_time - data["created_at"] > 30:  # GET req not seen for 30 secs
-            expired_tokens.append(token)
-
-    for token in expired_tokens:
-        data = download_tokens.pop(token)
-        # in case local zip file wasn't deleted by background task
-        remove_file(data["path"])
-
+        if job_id in active_zip_jobs:
+            active_zip_jobs[job_id]["status"] = "ready"
+            active_zip_jobs[job_id]["path"] = zip_path
+            
+    except Exception as e:
+        if job_id in active_zip_jobs:
+            active_zip_jobs[job_id]["status"] = "error"
 
 @recordings_router.get("", summary="Get all recordings")
 def get_recordings(request: Request) -> list[RecordingInfo]:
@@ -70,25 +77,32 @@ def get_disk_usage(request: Request) -> DiskStatsResponse:
     return DiskStatsResponse(total=total, used=used, free=free)
 
 
-@recordings_router.post("/zip/prepare", summary="Zip files and generate token")
-def prepare_zip_download(
+@recordings_router.post("/zip/prepare", summary="Start background zip job")
+def start_zip_job(
     request: Request,
-    filenames: list[str] = Body(...),  # noqa: B008
+    background_tasks: BackgroundTasks,
+    filenames: list[str] = Body(...), # noqa: B008
 ) -> dict:
-    clean_orphaned_tokens()
+    job_id = uuid.uuid4().hex
+    active_zip_jobs[job_id] = {"status": "zipping", "cancel": False, "path": None, "created_at": time.time(), "progress": 0}    
+    recordings_service = request.app.state.recordings_service
+    background_tasks.add_task(background_zip_worker, job_id, filenames, recordings_service)
+    background_tasks.add_task(auto_cleanup_job, job_id)
 
-    recordings_service: RecordingsService = request.app.state.recordings_service
+    return {"job_id": job_id}
 
-    zip_file_path = recordings_service.zip_recordings(filenames)
+@recordings_router.get("/zip/status/{job_id}", summary="Check zip job status")
+def check_zip_status(job_id: str) -> dict:
+    if job_id not in active_zip_jobs:
+         raise HTTPException(status_code=404, detail="Job not found")
+    job = active_zip_jobs[job_id]
+    return {"status": job["status"], "progress": job.get("progress", 0)}
 
-    if not zip_file_path or not os.path.exists(zip_file_path):
-        raise HTTPException(status_code=404, detail="No recordings to zip")
-
-    token = uuid.uuid4().hex
-    download_tokens[token] = {"path": zip_file_path, "created_at": time.time()}
-
-    return {"token": token}
-
+@recordings_router.post("/zip/cancel/{job_id}", summary="Cancel a zip job")
+def cancel_zip_job(job_id: str) -> dict:
+    if job_id in active_zip_jobs:
+        active_zip_jobs[job_id]["cancel"] = True
+    return {"message": "Cancellation requested"}
 
 @recordings_router.get("/zip/download", summary="Download ZIP using token")
 def download_zip(
@@ -96,13 +110,13 @@ def download_zip(
     background_tasks: BackgroundTasks,
     filename: str = "selected_recordings.zip",
 ) -> FileResponse:
-    if token not in download_tokens:
+    if token not in active_zip_jobs:
         raise HTTPException(status_code=404, detail="Invalid or expired download token")
 
-    token_data = download_tokens.pop(token)
-    zip_file_path = token_data["path"]
+    job_data = active_zip_jobs.pop(token)
+    zip_file_path = job_data.get("path")
 
-    if not os.path.exists(zip_file_path):
+    if not zip_file_path or not os.path.exists(zip_file_path):
         raise HTTPException(status_code=404, detail="Zip file not found")
 
     background_tasks.add_task(remove_file, zip_file_path)

--- a/backend_py/src/routes/recordings.py
+++ b/backend_py/src/routes/recordings.py
@@ -28,12 +28,15 @@ class DiskStatsResponse(BaseModel):
     used: int
     free: int
 
+
 active_zip_jobs: dict[str, dict] = {}
+
 
 # Helpers
 def remove_file(path: str) -> None:
     if os.path.exists(path):
         os.remove(path)
+
 
 # for refreshes during downloads
 async def auto_cleanup_job(job_id: str) -> None:
@@ -42,11 +45,16 @@ async def auto_cleanup_job(job_id: str) -> None:
         data = active_zip_jobs.pop(job_id)
         if data.get("path"):
             remove_file(data["path"])
-            
-def background_zip_worker(job_id: str, filenames: list[str], service: RecordingsService):
+
+
+def background_zip_worker(
+    job_id: str, filenames: list[str], service: RecordingsService
+) -> None:
     try:
-        zip_path = service.zip_recordings(filenames, active_jobs=active_zip_jobs, job_id=job_id)
-        
+        zip_path = service.zip_recordings(
+            filenames, active_jobs=active_zip_jobs, job_id=job_id
+        )
+
         if zip_path == "CANCELLED":
             active_zip_jobs.pop(job_id, None)
             return
@@ -54,10 +62,11 @@ def background_zip_worker(job_id: str, filenames: list[str], service: Recordings
         if job_id in active_zip_jobs:
             active_zip_jobs[job_id]["status"] = "ready"
             active_zip_jobs[job_id]["path"] = zip_path
-            
-    except Exception as e:
+
+    except Exception:
         if job_id in active_zip_jobs:
             active_zip_jobs[job_id]["status"] = "error"
+
 
 @recordings_router.get("", summary="Get all recordings")
 def get_recordings(request: Request) -> list[RecordingInfo]:
@@ -81,28 +90,39 @@ def get_disk_usage(request: Request) -> DiskStatsResponse:
 def start_zip_job(
     request: Request,
     background_tasks: BackgroundTasks,
-    filenames: list[str] = Body(...), # noqa: B008
+    filenames: list[str] = Body(...),  # noqa: B008
 ) -> dict:
     job_id = uuid.uuid4().hex
-    active_zip_jobs[job_id] = {"status": "zipping", "cancel": False, "path": None, "created_at": time.time(), "progress": 0}    
+    active_zip_jobs[job_id] = {
+        "status": "zipping",
+        "cancel": False,
+        "path": None,
+        "created_at": time.time(),
+        "progress": 0,
+    }
     recordings_service = request.app.state.recordings_service
-    background_tasks.add_task(background_zip_worker, job_id, filenames, recordings_service)
+    background_tasks.add_task(
+        background_zip_worker, job_id, filenames, recordings_service
+    )
     background_tasks.add_task(auto_cleanup_job, job_id)
 
     return {"job_id": job_id}
 
+
 @recordings_router.get("/zip/status/{job_id}", summary="Check zip job status")
 def check_zip_status(job_id: str) -> dict:
     if job_id not in active_zip_jobs:
-         raise HTTPException(status_code=404, detail="Job not found")
+        raise HTTPException(status_code=404, detail="Job not found")
     job = active_zip_jobs[job_id]
     return {"status": job["status"], "progress": job.get("progress", 0)}
+
 
 @recordings_router.post("/zip/cancel/{job_id}", summary="Cancel a zip job")
 def cancel_zip_job(job_id: str) -> dict:
     if job_id in active_zip_jobs:
         active_zip_jobs[job_id]["cancel"] = True
     return {"message": "Cancellation requested"}
+
 
 @recordings_router.get("/zip/download", summary="Download ZIP using token")
 def download_zip(

--- a/backend_py/src/services/recordings/recordings_service.py
+++ b/backend_py/src/services/recordings/recordings_service.py
@@ -162,24 +162,36 @@ class RecordingsService:
             return self.recordings
         return None
 
-    def zip_recordings(self, filenames: list[str] | None = None) -> str | None:
+    def zip_recordings(self, filenames: list[str] | None = None, active_jobs: dict | None = None, job_id: str | None = None) -> str | None:
         self.get_recordings()
         if not self.recordings:
             return None
 
+        targets = []
+        for recording in self.recordings:
+            full_name = f"{recording.name}.{recording.format}"
+            if filenames is not None and recording.name not in filenames and full_name not in filenames:
+                continue
+            targets.append((recording, full_name))
+
+        total_files = len(targets)
+        if total_files == 0:
+            return None
+        
         unique_id = uuid.uuid4().hex
         zip_filename = os.path.join(self.recordings_path, f"temp_{unique_id}.zip")
 
         with zipfile.ZipFile(zip_filename, "w") as zipf:
-            for recording in self.recordings:
-                full_name = f"{recording.name}.{recording.format}"
+            for i, (recording, full_name) in enumerate(targets):
+                if active_jobs is not None and job_id is not None:
+                    if active_jobs.get(job_id, {}).get("cancel", False):
+                        zipf.close()
+                        if os.path.exists(zip_filename):
+                            os.remove(zip_filename)
+                        return "CANCELLED"
 
-                if (
-                    filenames is not None
-                    and recording.name not in filenames
-                    and full_name not in filenames
-                ):
-                    continue
+                    progress = int((i / total_files) * 100)
+                    active_jobs[job_id]["progress"] = progress
 
                 zipf.write(recording.path, arcname=full_name)
         return zip_filename

--- a/backend_py/src/services/recordings/recordings_service.py
+++ b/backend_py/src/services/recordings/recordings_service.py
@@ -162,7 +162,12 @@ class RecordingsService:
             return self.recordings
         return None
 
-    def zip_recordings(self, filenames: list[str] | None = None, active_jobs: dict | None = None, job_id: str | None = None) -> str | None:
+    def zip_recordings(
+        self,
+        filenames: list[str] | None = None,
+        active_jobs: dict | None = None,
+        job_id: str | None = None,
+    ) -> str | None:
         self.get_recordings()
         if not self.recordings:
             return None
@@ -170,14 +175,18 @@ class RecordingsService:
         targets = []
         for recording in self.recordings:
             full_name = f"{recording.name}.{recording.format}"
-            if filenames is not None and recording.name not in filenames and full_name not in filenames:
+            if (
+                filenames is not None
+                and recording.name not in filenames
+                and full_name not in filenames
+            ):
                 continue
             targets.append((recording, full_name))
 
         total_files = len(targets)
         if total_files == 0:
             return None
-        
+
         unique_id = uuid.uuid4().hex
         zip_filename = os.path.join(self.recordings_path, f"temp_{unique_id}.zip")
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
                 "@radix-ui/react-dialog": "^1.1.6",
                 "@radix-ui/react-dropdown-menu": "^2.1.2",
                 "@radix-ui/react-label": "^2.1.8",
+                "@radix-ui/react-progress": "^1.1.8",
                 "@radix-ui/react-radio-group": "^1.3.6",
                 "@radix-ui/react-scroll-area": "^1.2.6",
                 "@radix-ui/react-select": "^2.1.6",
@@ -127,6 +128,7 @@
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -2075,6 +2077,68 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+            "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-context": "1.1.3",
+                "@radix-ui/react-primitive": "2.1.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+            "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+            "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.4"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-radio-group": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.6.tgz",
@@ -3462,6 +3526,7 @@
             "integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -3477,6 +3542,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
             "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
@@ -3488,6 +3554,7 @@
             "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -3534,6 +3601,7 @@
             "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.31.0",
                 "@typescript-eslint/types": "8.31.0",
@@ -3801,7 +3869,8 @@
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
             "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/acorn": {
             "version": "8.15.0",
@@ -3809,6 +3878,7 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4043,6 +4113,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "caniuse-lite": "^1.0.30001688",
                 "electron-to-chromium": "^1.5.73",
@@ -4536,6 +4607,7 @@
             "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5121,6 +5193,7 @@
             "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
             "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/immer"
@@ -6555,6 +6628,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -6740,6 +6814,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -6752,6 +6827,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -7399,6 +7475,7 @@
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
             "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@alloc/quick-lru": "^5.2.0",
                 "arg": "^5.0.2",
@@ -7550,6 +7627,7 @@
             "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -7830,6 +7908,7 @@
             "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.21.3",
                 "postcss": "^8.4.43",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-progress": "^1.1.8",
         "@radix-ui/react-radio-group": "^1.3.6",
         "@radix-ui/react-scroll-area": "^1.2.6",
         "@radix-ui/react-select": "^2.1.6",

--- a/frontend/src/components/dwe/recordings/components/recording-modals.tsx
+++ b/frontend/src/components/dwe/recordings/components/recording-modals.tsx
@@ -2,16 +2,6 @@ import {
   recordingsActions,
   recordingsState,
 } from "@/components/dwe/recordings/store/recording-store";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -146,44 +136,87 @@ export const RecordingModals = ({ baseUrl }: { baseUrl: string }) => {
       </Dialog>
 
       {/* Delete Dialog */}
-      <AlertDialog
+      <Dialog
         open={snap.deleteTargets.length > 0}
         onOpenChange={(open) => !open && recordingsActions.closeDelete()}
       >
-        <AlertDialogContent>
-          <AlertDialogHeader>
+        <DialogContent>
+          <DialogHeader>
             <div className="flex items-center gap-3">
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/15 text-destructive">
                 <AlertTriangle className="h-5 w-5" />
               </div>
-              <div>
-                <AlertDialogTitle>Delete recording?</AlertDialogTitle>
-                <AlertDialogDescription>
+              <div className="text-left">
+                <DialogTitle>Delete recording?</DialogTitle>
+                <DialogDescription>
                   This action cannot be undone.
-                </AlertDialogDescription>
+                </DialogDescription>
               </div>
             </div>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
               disabled={snap.deleteSubmitting}
               onClick={recordingsActions.closeDelete}
             >
               Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
+            </Button>
+            <Button
+              variant="destructive"
+              disabled={snap.deleteSubmitting}
               onClick={(e) => {
                 e.preventDefault();
                 recordingsActions.performDelete();
               }}
-              disabled={snap.deleteSubmitting}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {snap.deleteSubmitting ? "Deleting..." : "Delete"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Cancel All Downloads Dialog */}
+      <Dialog
+        open={snap.isCancelAllZipModalOpen}
+        onOpenChange={(open) =>
+          !open && recordingsActions.closeCancelAllModal()
+        }
+      >
+        <DialogContent>
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive/15 text-destructive">
+                <AlertTriangle className="h-5 w-5" />
+              </div>
+              <div className="text-left">
+                <DialogTitle>Cancel all downloads?</DialogTitle>
+                <DialogDescription>
+                  This will immediately stop all active zipping tasks.
+                  Incomplete files will be deleted.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={recordingsActions.closeCancelAllModal}
+            >
+              Keep Downloading
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={(e) => {
+                e.preventDefault();
+                recordingsActions.cancelAllZips(baseUrl);
+              }}
+            >
+              Cancel Downloads
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/components/dwe/recordings/components/recording-table.tsx
+++ b/frontend/src/components/dwe/recordings/components/recording-table.tsx
@@ -227,12 +227,12 @@ export const RecordingTable = ({
 
       <Table noWrapper className="table-fixed">
         <TableHeader
-          className="bg-background sticky top-0 z-10 select-none"
+          className="bg-background sticky top-0 z-10 select-none w-full"
           onMouseDown={(e) => e.stopPropagation()}
         >
           <TableRow className="text-left text-gray-500 font-bold">
             <TableCell
-              className="cursor-pointer hover:bg-muted w-auto"
+              className="cursor-pointer hover:bg-muted w-full"
               onClick={() => onSort("name")}
             >
               Name&nbsp;&nbsp;
@@ -261,6 +261,7 @@ export const RecordingTable = ({
               Size&nbsp;&nbsp;
               {sortColumn === "size" && (sortDirection === "asc" ? "▲" : "▼")}
             </TableCell>
+            <TableCell className="cursor-pointer hover:bg-muted w-12" />
           </TableRow>
         </TableHeader>
         <TableBody className="select-none">
@@ -324,18 +325,18 @@ export const RecordingTable = ({
                     />
                   </div>
                 </TableCell>
-                <TableCell className="text-left w-24">
+                <TableCell className="text-left">
                   {formatDate(recording.created)}
                 </TableCell>
-                <TableCell className="text-left w-24">
+                <TableCell className="text-left">
                   {recording.duration}
                 </TableCell>
-                <TableCell className="text-left w-24">
+                <TableCell className="text-left">
                   {formatFileSize(
                     recording.size ? parseFloat(recording.size) : 0,
                   )}
                 </TableCell>
-                <TableCell className="text-right w-16 p-0 pr-2">
+                <TableCell className="text-right p-0 pr-2">
                   <Button
                     variant="ghost"
                     className="h-8 w-8 p-0"

--- a/frontend/src/components/dwe/recordings/recordings.tsx
+++ b/frontend/src/components/dwe/recordings/recordings.tsx
@@ -315,10 +315,10 @@ const Recordings = () => {
                     animate-in slide-in-from-bottom-10 fade-in duration-300"
         >
           <div
-            className="flex w-full justify-between item p-4 gap-2 border-b"
+            className="flex w-full justify-between items-center p-2 gap-2 border-b"
             onClick={() => recordingsActions.toggleZipDrawer()}
           >
-            <Button variant="svg" className="p-0 h-auto">
+            <Button variant="svg" className="p-2 h-auto">
               <ChevronDown
                 className={cn(
                   "size-4 transition-transform duration-300",
@@ -331,7 +331,7 @@ const Recordings = () => {
             </span>
             <Button
               variant="svg"
-              className="p-0 h-auto"
+              className="p-2 h-auto"
               onClick={(e) => {
                 e.stopPropagation();
                 recordingsActions.openCancelAllModal();
@@ -347,9 +347,12 @@ const Recordings = () => {
             )}
           >
             <div className="overflow-hidden">
-              <div className="flex flex-col max-h-[40vh] overflow-y-auto p-2">
+              <div className="flex flex-col max-h-[40vh] overflow-y-auto overflow-x-hidden p-2">
                 {snap.zipJobs.map((job) => (
-                  <div key={job.id} className=" p-4 flex flex-col gap-3">
+                  <div
+                    key={job.id}
+                    className=" p-4 flex flex-col gap-3 animate-in slide-in-from-right-10 fade-in duration-300"
+                  >
                     <div className="flex justify-between items-center">
                       <div className="flex flex-col w-full gap-2">
                         <span className="flex items-center gap-2 text-sm font-medium">

--- a/frontend/src/components/dwe/recordings/recordings.tsx
+++ b/frontend/src/components/dwe/recordings/recordings.tsx
@@ -10,11 +10,13 @@ import { useTour } from "@/components/tour/tour";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Input } from "@/components/ui/input";
+import { Progress } from "@/components/ui/progress";
 import { Spinner } from "@/components/ui/spinner";
 import { TOUR_STEP_IDS } from "@/lib/tour-constants";
+import { cn } from "@/lib/utils";
 import { components } from "@/schemas/dwe_os_2";
-import { Circle, Download, Search, Trash2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, Circle, Download, Search, Trash2, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSnapshot } from "valtio";
 
 type RecordingInfo = components["schemas"]["RecordingInfo"];
@@ -27,6 +29,7 @@ const Recordings = () => {
   const snap = useSnapshot(recordingsState);
   const { isActive } = useTour();
 
+  const containerRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortColumn, setSortColumn] = useState<keyof RecordingInfo | null>(
     null,
@@ -38,6 +41,36 @@ const Recordings = () => {
   // initial data fetch
   useEffect(() => {
     recordingsActions.fetchRecordings();
+  }, []);
+
+  // global listener for clicks outside of table
+  useEffect(() => {
+    const handleGlobalPointerDown = (e: PointerEvent) => {
+      if (recordingsState.selectedNames.length === 0) return;
+
+      const target = e.target as HTMLElement;
+
+      if (
+        // ignore clicks inside the table
+        target.closest(
+          'tr, thead, [role="row"], [role="columnheader"], .rt-tr',
+        ) ||
+        // ignore clicks inside context menus/modals
+        target.closest(
+          '[role="menu"], [role="dialog"], [data-radix-popper-content-wrapper]',
+        ) ||
+        // ignore clicks on action buttons inside recordings
+        (target.closest("button, input, a") &&
+          containerRef.current?.contains(target))
+      ) {
+        return;
+      }
+      recordingsActions.setSelectedNames([]);
+    };
+
+    document.addEventListener("pointerdown", handleGlobalPointerDown);
+    return () =>
+      document.removeEventListener("pointerdown", handleGlobalPointerDown);
   }, []);
 
   const handleSort = (column: keyof RecordingInfo) => {
@@ -110,6 +143,7 @@ const Recordings = () => {
 
   return (
     <div
+      ref={containerRef}
       className="flex flex-col h-[calc(100vh-5.5rem)] gap-2"
       id={TOUR_STEP_IDS.REC_PAGE}
     >
@@ -125,7 +159,7 @@ const Recordings = () => {
       </div>
 
       <div className="flex min-h-0 flex-1">
-        <div className="flex-1 min-w-0 overflow-x-auto border rounded-xl">
+        <div className="flex-1 min-w-0 overflow-x-auto border rounded-md">
           <RecordingTable
             recordings={displayRecordings}
             loading={snap.loading}
@@ -144,47 +178,69 @@ const Recordings = () => {
           {/* BUTTONS */}
           <div className="shrink-0">
             {snap.selectedNames.length > 0 ? (
-              <ButtonGroup>
-                <Button
-                  variant="outline"
-                  className="cursor-pointer"
-                  onClick={() => recordingsActions.downloadZip(baseUrl)}
-                  disabled={snap.zipDownloading || snap.recordings.length === 0}
-                >
-                  {snap.zipDownloading ? (
-                    <div className="flex items-center gap-2">
-                      Zipping <Spinner className="size-4" />
-                    </div>
-                  ) : (
+              <div className="flex gap-4 items-center">
+                <ButtonGroup>
+                  <Button
+                    variant="outline"
+                    className="cursor-pointer"
+                    onClick={() => {
+                      if (snap.selectedNames.length > 1) {
+                        recordingsActions.downloadZip(baseUrl);
+                      } else if (snap.selectedNames.length === 1) {
+                        const targetRecording = snap.recordings.find(
+                          (r) => r.name === snap.selectedNames[0],
+                        );
+                        if (targetRecording) {
+                          recordingsActions.downloadRecording(
+                            targetRecording,
+                            baseUrl,
+                          );
+                          recordingsActions.setSelectedNames([]);
+                        }
+                      }
+                    }}
+                  >
                     <Download className="size-4" />
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  className="cursor-pointer hover:bg-destructive"
-                  disabled={
-                    snap.deleteSubmitting || snap.recordings.length === 0
-                  }
-                  onClick={() => {
-                    const selectedRecs = snap.recordings.filter((r) =>
-                      snap.selectedNames.includes(r.name),
-                    );
-                    recordingsActions.openDelete(
-                      (snap.selectedNames.length > 0
-                        ? selectedRecs
-                        : snap.recordings) as RecordingInfo[],
-                    );
-                  }}
-                >
-                  {snap.deleteSubmitting ? (
-                    <div className="flex items-center gap-2">
-                      Trashing <Spinner className="size-4" />
-                    </div>
-                  ) : (
-                    <Trash2 className="size-4" />
-                  )}
-                </Button>
-              </ButtonGroup>
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="cursor-pointer hover:bg-destructive"
+                    disabled={
+                      snap.deleteSubmitting || snap.recordings.length === 0
+                    }
+                    onClick={() => {
+                      const selectedRecs = snap.recordings.filter((r) =>
+                        snap.selectedNames.includes(r.name),
+                      );
+                      recordingsActions.openDelete(
+                        (snap.selectedNames.length > 0
+                          ? selectedRecs
+                          : snap.recordings) as RecordingInfo[],
+                      );
+                    }}
+                  >
+                    {snap.deleteSubmitting ? (
+                      <div className="flex items-center gap-2">
+                        Trashing <Spinner className="size-4" />
+                      </div>
+                    ) : (
+                      <Trash2 className="size-4" />
+                    )}
+                  </Button>
+                </ButtonGroup>
+                <div className="flex bg-muted items-center border px-2 gap-2  rounded-md">
+                  <span className="text-sm text-muted-foreground">
+                    {snap.selectedNames.length} selected
+                  </span>
+                  <Button
+                    variant="svg"
+                    className="p-0 h-8"
+                    onClick={() => recordingsActions.setSelectedNames([])}
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </div>
+              </div>
             ) : (
               <Button
                 variant="outline"
@@ -251,6 +307,77 @@ const Recordings = () => {
 
       <RecordingContextMenu baseUrl={baseUrl} />
       <RecordingModals baseUrl={baseUrl} />
+
+      {snap.zipJobs && snap.zipJobs.length > 0 && (
+        <div
+          className="fixed bottom-0 right-6 flex flex-col z-50 w-80 bg-card/50 
+                    backdrop-blur-sm rounded-t-md border-t border-x
+                    animate-in slide-in-from-bottom-10 fade-in duration-300"
+        >
+          <div
+            className="flex w-full justify-between item p-4 gap-2 border-b"
+            onClick={() => recordingsActions.toggleZipDrawer()}
+          >
+            <Button variant="svg" className="p-0 h-auto">
+              <ChevronDown
+                className={cn(
+                  "size-4 transition-transform duration-300",
+                  snap.isZipDrawerMinimized ? "rotate-180" : "",
+                )}
+              />
+            </Button>
+            <span className="text-sm font-semibold ml-1">
+              {snap.zipJobs.length} Download{snap.zipJobs.length > 1 ? "s" : ""}
+            </span>
+            <Button
+              variant="svg"
+              className="p-0 h-auto"
+              onClick={(e) => {
+                e.stopPropagation();
+                recordingsActions.openCancelAllModal();
+              }}
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+          <div
+            className={cn(
+              "grid transition-all duration-300 ease-in-out",
+              snap.isZipDrawerMinimized ? "grid-rows-[0fr]" : "grid-rows-[1fr]",
+            )}
+          >
+            <div className="overflow-hidden">
+              <div className="flex flex-col max-h-[40vh] overflow-y-auto p-2">
+                {snap.zipJobs.map((job) => (
+                  <div key={job.id} className=" p-4 flex flex-col gap-3">
+                    <div className="flex justify-between items-center">
+                      <div className="flex flex-col w-full gap-2">
+                        <span className="flex items-center gap-2 text-sm font-medium">
+                          <Spinner className="size-4" /> Zipping{" "}
+                          {job.totalFiles} items...
+                        </span>
+                        <Progress
+                          value={job.progress}
+                          className="h-1.5 w-full"
+                        />
+                      </div>
+                      <Button
+                        variant="svg"
+                        onClick={() =>
+                          recordingsActions.cancelZip(baseUrl, job.id)
+                        }
+                        className="text-muted-foreground hover:text-foreground transition-colors py-0 pl-2 pr-0"
+                      >
+                        <X className="size-4" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/dwe/recordings/store/recording-store.tsx
+++ b/frontend/src/components/dwe/recordings/store/recording-store.tsx
@@ -12,12 +12,21 @@ interface DiskStats {
   used: number;
   free: number;
 }
+
+interface ZipJob {
+  id: string;
+  progress: number;
+  status: "zipping" | "ready" | "error";
+  totalFiles: number;
+}
 interface RecordingsState {
   recordings: RecordingInfo[];
   diskStats: DiskStats | null;
   selectedNames: string[];
   loading: boolean;
-  zipDownloading: boolean;
+  zipJobs: ZipJob[];
+  isZipDrawerMinimized: boolean;
+  isCancelAllZipModalOpen: boolean;
 
   // Modal Targets
   playTarget: RecordingInfo | null;
@@ -44,7 +53,9 @@ export const recordingsState = proxy<RecordingsState>({
   diskStats: null,
   selectedNames: [],
   loading: true,
-  zipDownloading: false,
+  zipJobs: [],
+  isZipDrawerMinimized: false,
+  isCancelAllZipModalOpen: false,
   playTarget: null,
   renameTarget: null,
   deleteTargets: [],
@@ -93,12 +104,13 @@ export const recordingsActions = {
   },
 
   downloadZip: async (baseUrl: string) => {
-    if (recordingsState.zipDownloading) return;
-    const selected = recordingsState.selectedNames;
+    const selected = [...recordingsState.selectedNames];
     if (recordingsState.recordings.length === 0 || selected.length === 0)
       return;
 
-    recordingsState.zipDownloading = true;
+    recordingsActions.setSelectedNames([]);
+    recordingsState.isZipDrawerMinimized = false;
+
     try {
       const response = await fetch(`${baseUrl}/api/recordings/zip/prepare`, {
         method: "POST",
@@ -106,38 +118,106 @@ export const recordingsActions = {
         body: JSON.stringify(selected),
       });
 
-      if (!response.ok) {
-        let description = `Server responded with ${response.status}.`;
-        try {
-          const data = await response.json();
-          if (data?.detail) description = data.detail;
-        } catch {
-          /* empty */
+      const { job_id } = await response.json();
+      recordingsState.zipJobs.push({
+        id: job_id,
+        progress: 0,
+        status: "zipping",
+        totalFiles: selected.length,
+      });
+
+      // poll every 0.5 seconds for progress
+      const pollInterval = setInterval(async () => {
+        const jobIndex = recordingsState.zipJobs.findIndex(
+          (j) => j.id === job_id,
+        );
+
+        if (jobIndex === -1) {
+          clearInterval(pollInterval);
+          return;
         }
-        toast.error("Failed to download recordings", { description });
-        return;
-      }
 
-      const { token } = await response.json();
+        const statusRes = await fetch(
+          `${baseUrl}/api/recordings/zip/status/${job_id}`,
+        );
+        if (!statusRes.ok) {
+          clearInterval(pollInterval);
+          recordingsState.zipJobs.splice(jobIndex, 1);
+          return;
+        }
 
-      const filename =
-        selected.length === recordingsState.recordings.length
-          ? "all_recordings.zip"
-          : "selected_recordings.zip";
+        const { status, progress } = await statusRes.json();
+        recordingsState.zipJobs[jobIndex].progress = progress || 0;
 
-      const downloadUrl = `${baseUrl}/api/recordings/zip/download?token=${token}&filename=${filename}`;
-      const link = document.createElement("a");
-      link.href = downloadUrl;
-      link.download = filename;
-      document.body.appendChild(link);
-      link.click();
-      link.remove();
-    } catch (error) {
-      console.error("Error downloading zip:", error);
-      toast.error("Failed to download recordings");
-    } finally {
-      recordingsState.zipDownloading = false;
+        if (status === "ready") {
+          clearInterval(pollInterval);
+          recordingsState.zipJobs[jobIndex].status = "ready";
+          recordingsState.zipJobs[jobIndex].progress = 100;
+
+          const downloadUrl = `${baseUrl}/api/recordings/zip/download?token=${job_id}&filename=selected_recordings.zip`;
+          const link = document.createElement("a");
+          link.href = downloadUrl;
+          document.body.appendChild(link);
+          link.click();
+          link.remove();
+
+          setTimeout(() => {
+            const idx = recordingsState.zipJobs.findIndex(
+              (j) => j.id === job_id,
+            );
+            if (idx !== -1) recordingsState.zipJobs.splice(idx, 1);
+          }, 800);
+        } else if (status === "error") {
+          clearInterval(pollInterval);
+          recordingsState.zipJobs.splice(jobIndex, 1);
+          toast.error("Zipping failed on server.");
+        }
+      }, 500);
+    } catch {
+      toast.error("Failed to start download");
     }
+  },
+
+  cancelZip: async (baseUrl: string, jobId: string) => {
+    try {
+      await fetch(`${baseUrl}/api/recordings/zip/cancel/${jobId}`, {
+        method: "POST",
+      });
+      const idx = recordingsState.zipJobs.findIndex((j) => j.id === jobId);
+      if (idx !== -1) recordingsState.zipJobs.splice(idx, 1);
+    } catch (error) {
+      console.error("Error cancelling job:", error);
+    }
+  },
+
+  cancelAllZips: async (baseUrl: string) => {
+    const activeJobs = [...recordingsState.zipJobs];
+
+    recordingsState.zipJobs = [];
+    recordingsState.isZipDrawerMinimized = false;
+    recordingsState.isCancelAllZipModalOpen = false;
+
+    for (const job of activeJobs) {
+      try {
+        await fetch(`${baseUrl}/api/recordings/zip/cancel/${job.id}`, {
+          method: "POST",
+        });
+      } catch (error) {
+        console.error(`Error cancelling job ${job.id}:`, error);
+      }
+    }
+  },
+
+  toggleZipDrawer: () => {
+    recordingsState.isZipDrawerMinimized =
+      !recordingsState.isZipDrawerMinimized;
+  },
+
+  openCancelAllModal: () => {
+    recordingsState.isCancelAllZipModalOpen = true;
+  },
+  closeCancelAllModal: () => {
+    recordingsState.isCancelAllZipModalOpen = false;
   },
 
   // Modal

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-2 w-full overflow-hidden rounded-full bg-primary/20",
+      className,
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };


### PR DESCRIPTION
## Summary

Couple of tweaks for recordings tab
- Download has been made more descriptive, including download "progress", cancelling downloads, cancelling all downloads, and a new drawer for downloads to exist in.
- changed how temporary zip files clean up, they will now clean themselves up after 10 minutes (refresh), or be deleted at the conclusion of a job, or be deleted upon cancellation.
- include "selected files" widget at the footer and upgraded unselect all to include clicks outside of the table.
- changed alert dialogs to dialogs so they natively come with closing upon clicking on the dialog overlay.
- small styling tweaks, like the name section not automatically filling the rest of the available table space.

- [x] Bug fix
- [x] Feature / Refactor
- [ ] Breaking change
- [x] Misc.

## Quick Checklist

- [x] I have reviewed my own code.
- [x] I have tested these changes locally.
- [ ] I have tested these changes on the following platforms (optional):
  - [ ] SVC
  - [ ] microSVC (optional)
  - [ ] SVC Pro
